### PR TITLE
Fix blog post order

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -5,7 +5,7 @@ const today = new Date();
 ---
 
 <footer>
-  <p>Since 2024 by Marcos Gil.</p>
+  <p>© 2024-{today.getFullYear()} Marcos Gil.</p>
   <p>Made in Spain 🇪🇸</p>
   <SocialIcons />
 </footer>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -5,10 +5,9 @@ import Footer from '../../components/Footer.astro';
 import { SITE_TITLE, SITE_DESCRIPTION } from '../../consts';
 import { getCollection } from 'astro:content';
 import FormattedDate from '../../components/FormattedDate.astro';
+import { sortPosts } from '../../utils/sort';
 
-const posts = (await getCollection('blog')).sort(
-  (a, b) => a.data.pubDate.valueOf() - b.data.pubDate.valueOf(),
-);
+const posts = sortPosts(await getCollection('blog'));
 ---
 
 <!doctype html>

--- a/src/utils/sort.test.js
+++ b/src/utils/sort.test.js
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest';
+import { sortPosts } from './sort';
+
+describe('sortPosts', () => {
+  it('sorts posts by pubDate descending', () => {
+    const posts = [
+      { data: { pubDate: new Date('2020-01-01') } },
+      { data: { pubDate: new Date('2021-01-01') } },
+      { data: { pubDate: new Date('2019-01-01') } },
+    ];
+    const sorted = sortPosts(posts);
+    expect(sorted[0].data.pubDate.getFullYear()).toBe(2021);
+    expect(sorted[1].data.pubDate.getFullYear()).toBe(2020);
+    expect(sorted[2].data.pubDate.getFullYear()).toBe(2019);
+  });
+});

--- a/src/utils/sort.ts
+++ b/src/utils/sort.ts
@@ -1,0 +1,5 @@
+export function sortPosts<T extends { data: { pubDate: Date } }>(posts: T[]): T[] {
+  return [...posts].sort(
+    (a, b) => b.data.pubDate.getTime() - a.data.pubDate.getTime(),
+  );
+}


### PR DESCRIPTION
## Summary
- show newest blog posts first
- extract sortPosts helper and test it
- move sort helper to src/utils folder
- return a new array from sort helper
- display dynamic copyright year

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ab6c84a8483318d80db453aff294b