### PR TITLE
Fix typo in global styles comment

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -149,6 +149,6 @@ hr {
 	clip: rect(1px, 1px, 1px, 1px);
 	/* modern browsers, clip-path works inwards from each corner */
 	clip-path: inset(50%);
-	/* added line to stop words getting smushed together (as they go onto seperate lines and some screen readers do not understand line feeds as a space */
+        /* added line to stop words getting smushed together (as they go onto separate lines and some screen readers do not understand line feeds as a space */
 	white-space: nowrap;
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -149,6 +149,6 @@ hr {
 	clip: rect(1px, 1px, 1px, 1px);
 	/* modern browsers, clip-path works inwards from each corner */
 	clip-path: inset(50%);
-        /* added line to stop words getting smushed together (as they go onto separate lines and some screen readers do not understand line feeds as a space */
+        /* Ensures words remain on the same line to prevent screen readers from misinterpreting line breaks as missing spaces, improving accessibility. */
 	white-space: nowrap;
 }


### PR DESCRIPTION
## Summary
- correct spelling of "separate" in screen-reader helper comment

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c8ae6b5f4833188411da98c6a4e30