### PR TITLE
Update CONTRIBUTING.md to use npm

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,10 +32,10 @@ git checkout -b my-awesome-fix
 
 ## Preparing Your Local Environment for Development
 
-Now that you have cloned the repository, ensure you have [yarn](https://classic.yarnpkg.com/lang/en/) installed, then run the following commands to set up the development environment.
+Now that you have cloned the repository, ensure you have [Node.js and npm](https://docs.npmjs.com/) installed, then run the following command to set up the development environment.
 
 ```sh
-yarn install
+npm install
 ```
 
 This will download and install all packages needed.
@@ -50,7 +50,7 @@ If you're making cross-package changes, you need to compile the TypeScript code.
 
 ### Running Tests
 
-To run the tests of a package, it's recommended to `cd` into the package directory and then using `yarn test` to run them. This way you're only running tests of that specific package.
+To run the tests of a package, it's recommended to `cd` into the package directory and then using `npm test` to run them. This way you're only running tests of that specific package.
 
 ### Integration Testing
 
@@ -58,7 +58,7 @@ To see how your changes integrate with everything together you can use the `test
 
 ## Adding New Packages
 
-For all projects the tsconfig/jsconfig configuration files are auto generated. You need to add an entry to the [./workspace-packages.ts](./workspace-packages.ts) to let it generate a config for you. After adding an entry, run `yarn update-package-configs` to generate the files for you.
+For all projects the tsconfig/jsconfig configuration files are auto generated. You need to add an entry to the [./workspace-packages.ts](./workspace-packages.ts) to let it generate a config for you. After adding an entry, run `npx update-package-configs` to generate the files for you.
 
 ## Creating a Changeset
 
@@ -70,7 +70,7 @@ This documents your intent to release, and allows you to specify a message that 
 Run
 
 ```sh
-yarn changeset
+npx changeset
 ```
 
 And use the menu to select for which packages you need a release, and then select what kind of release. For the release type, we follow [Semantic Versioning](https://semver.org/), so please take a look if you're unfamiliar.


### PR DESCRIPTION
## Summary
- use npm for installing packages
- update test instructions to use `npm test`
- use `npx` for workspace scripts

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: blocked by network)*

------
https://chatgpt.com/codex/tasks/task_e_684c8b08eb2c83319e0b3f6c8579bc45