### PR TITLE
Refresh AI Engineer docs and supporting context

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,0 +1,20 @@
+# ──────────────────────────────────────────────────
+# Development environment defaults
+# ──────────────────────────────────────────────────
+# This file is committed to the repo and contains
+# safe, non-secret defaults for local development.
+# Override any value locally in `.env` (gitignored).
+# ──────────────────────────────────────────────────
+
+# ── Site ──────────────────────────────────────────
+SITE_URL=http://localhost:4321
+SITE_TITLE=Marcos Gil (dev)
+SITE_DESCRIPTION=Personal website of Marcos Gil – development
+
+# ── Analytics ─────────────────────────────────────
+# Left empty so the /api/track endpoint short-circuits
+# in development (returns 204).
+INFLUX_URL=
+INFLUX_TOKEN=
+INFLUX_ORG=
+INFLUX_BUCKET=

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,25 @@
+# ──────────────────────────────────────────────────
+# Environment Variables Reference
+# ──────────────────────────────────────────────────
+# Copy this file to `.env` and fill in real values.
+# Astro/Vite loads env files by mode:
+#   astro dev   → .env.development > .env
+#   astro build → .env.production  > .env
+#
+# Variables prefixed with PUBLIC_ are available in
+# client-side code via import.meta.env.PUBLIC_*
+# All variables are available server-side.
+# ──────────────────────────────────────────────────
+
+# ── Site ──────────────────────────────────────────
+# Used in astro.config.mjs (site), meta tags, RSS, etc.
+SITE_URL=https://YOUR_DOMAIN
+SITE_TITLE=Your Site Title
+SITE_DESCRIPTION=Your site description
+
+# ── Analytics (InfluxDB) ─────────────────────────
+# Server-side only – used by the /api/track endpoint.
+INFLUX_URL=https://your-influxdb-instance
+INFLUX_TOKEN=your-influx-token
+INFLUX_ORG=your-org
+INFLUX_BUCKET=your-bucket

--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,10 @@ pnpm-debug.log*
 
 # environment variables
 .env
+.env.local
 .env.production
+.env.*.local
+# .env.development and .env.example are committed (safe defaults / docs)
 
 # macOS-specific files
 .DS_Store

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,27 @@ heroImage: string   # Optional (path in /public)
 - Lint/format uses Biome (`biome.json`).
 - Tests run with Vitest.
 
+## Environment Variables
+Configuration is driven by `.env` files loaded by Astro/Vite.
+See `.env.example` for the full reference.
+
+| Variable | Used in | Purpose |
+|---|---|---|
+| `SITE_URL` | `astro.config.mjs` | Canonical site URL (e.g. `https://example.com`) |
+| `SITE_TITLE` | `src/consts.ts` | Site name shown in header, meta, RSS |
+| `SITE_DESCRIPTION` | `src/consts.ts` | Default meta description |
+| `INFLUX_URL` | `src/pages/api/track.ts` | InfluxDB write endpoint |
+| `INFLUX_TOKEN` | `src/pages/api/track.ts` | InfluxDB auth token |
+| `INFLUX_ORG` | `src/pages/api/track.ts` | InfluxDB organisation |
+| `INFLUX_BUCKET` | `src/pages/api/track.ts` | InfluxDB bucket |
+| `CONTEXT` | `src/pages/api/track.ts` | Netlify deploy context (`production`, `deploy-preview`, …) |
+
+**File loading order** (Astro/Vite):
+- `astro dev` → `.env.development` > `.env`
+- `astro build` → `.env.production` > `.env`
+- `.env.development` is committed with safe dev defaults.
+- `.env` and `.env.production` are gitignored (contain secrets).
+
 ## Deployment (GitHub Actions -> Netlify)
 - CI workflow: `.github/workflows/ci.yml` runs lint/tests, builds, uploads `dist`, and invokes the preview deploy.
 - Preview workflow: `.github/workflows/deploy-preview.yml` is a reusable workflow invoked by CI for PRs to `main`, deploying `dist`.

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -2,11 +2,14 @@ import mdx from '@astrojs/mdx';
 import netlify from '@astrojs/netlify';
 import sitemap from '@astrojs/sitemap';
 import { defineConfig } from 'astro/config';
+import { loadEnv } from 'vite';
+
+const { SITE_URL } = loadEnv(process.env.NODE_ENV ?? '', process.cwd(), '');
 
 // https://astro.build/config
 export default defineConfig({
   output: 'server',
   adapter: netlify(),
-  site: 'https://www.marcosgilf.com',
+  site: SITE_URL,
   integrations: [mdx(), sitemap()],
 });

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -10,6 +10,6 @@ const { SITE_URL } = loadEnv(process.env.NODE_ENV ?? '', process.cwd(), '');
 export default defineConfig({
   output: 'server',
   adapter: netlify(),
-  site: SITE_URL,
+  site: SITE_URL || 'https://www.marcosgilf.com',
   integrations: [mdx(), sitemap()],
 });

--- a/docs/ai-engineer.md
+++ b/docs/ai-engineer.md
@@ -1,341 +1,181 @@
 # AI Engineer — Applied Agentic Engineering
 
+## Document Control
+
+| Version | Date | Source | Notes |
+|---|---|---|---|
+| v1 | 2026-01-23 | Commit `c22992c` (`docs: ai engineer plan`) | Initial AI Engineer direction with phase-based schedule constraints. |
+| v2 | 2026-02-18 | `instructions-v2.md`, `plan-v2.md`, nanobot specs (`iac.md`, `llm-router.md`, `memory-manager.md`, `wodbuster-booker.md`) | Preserves AI Engineer framing, removes fixed cadence, defines iterative execution, and aligns the roadmap with 2026–2027 AI trends. |
+
+---
+
 ## Purpose
 
-This document defines the long-term goal, current baseline, and high-level execution plan to deliberately transition from **Senior Software Engineer** to **Applied AI Engineer** focused on building production-grade AI agents and automation systems.
+This document defines the long-term direction to become an **AI Engineer** focused on building production-grade AI systems.  
+The current starting domain is **AI Agents**, because it combines runtime engineering, tool orchestration, evaluation, automation, and operational rigor.
 
-This is not a learning plan.
-This is a **professional identity shift**.
+This is a professional identity shift, executed through small and continuous delivery.
 
 ---
 
 ## North Star Goal
 
-Become an **Applied AI Engineer** capable of:
+Become an **AI Engineer** capable of:
 
-* Building **production AI agents** for business automation
-* Designing **modular, composable skills** (primitives) that teams can compose into workflows
-* Shipping autonomous workflows across sales, marketing, and operations
-* Owning the **AI development environment** (AI coding tools, templates, patterns, docs)
+- Building production AI systems with clear operational and quality guarantees.
+- Designing tool-using agents that are measurable, reliable, and controllable.
+- Shipping automation workflows with real integration boundaries and auditability.
+- Owning AI engineering standards: evals, observability, safety controls, and delivery playbooks.
 
-Target role archetypes (ordered by priority):
+Target role archetypes:
 
-1. **Senior Software Engineer, Applied AI**
-2. **AI Agent Engineer**
-3. **AI Automation Engineer**
-4. **AI Infrastructure Engineer**
+1. Senior Software Engineer, AI Engineer
+2. AI Agent Engineer
+3. AI Automation Engineer
+4. AI Infrastructure Engineer
 
-Explicit non-goal:
+---
 
-* Generic "AI integration" / shallow API demos
-* Prompt-only "agent" demos without evaluation, observability, or real automation
-* Research-only work without shippable systems
-* Core LLM/model development (deferred to future phase)
+## Scope for 2026–2027
+
+Initial specialization path:
+
+- AI Agents as the first execution domain.
+
+Long-term capability profile:
+
+- Agent runtime engineering.
+- Evaluation and regression systems.
+- Workflow automation and integrations.
+- Security and policy controls for autonomous systems.
+- Reliability and observability in production.
+- AI-enabled developer productivity and async operations.
+
+This keeps the identity broad as AI Engineer while using agents as the practical entry point.
+
+---
+
+## Current Starting Point
+
+The current work starts in **Nanobot** because it has the lowest learning curve and immediate deployability for real workflows.
+
+Why this is the right starting point:
+
+- Existing IaC and deploy pipeline already running.
+- Active skills (`memory-manager`, `wodbuster-booker`) and router (`llm-router`) provide realistic engineering surfaces.
+- Immediate feedback loops exist via tests, logs, and operational scripts.
+
+Boundary:
+
+- Nanobot is a launchpad for capability development.
+- Nanobot is not the final platform boundary for this roadmap.
 
 ---
 
 ## Definition of Success
 
-This journey is successful when **at least 3 of the following are true**:
+This journey is successful when at least three outcomes are true:
 
-* I can ship a tool-using agent that reliably executes multi-step workflows with measurable success criteria
-* I can build a **Skills library** (clean abstractions + schemas + docs) that a non-technical user can compose
-* I can productionize agents: logs/traces, retries, rate-limit handling, idempotency, run artifacts, regression tests
-* I can integrate with business systems (or faithful mocks) like CRM, docs, and chat platforms
-* I have public artifacts and write-ups that demonstrate end-to-end agentic systems and are easy to evaluate
-* My profile is credible to AI-native hiring loops
-* I can collaborate productively with AI researchers and product teams
+- Tool-using agent systems are shipped with replayable artifacts and measurable quality.
+- Evaluation and regression become standard delivery gates.
+- Production operations include observability, error handling, idempotency, and policy controls.
+- Public technical artifacts clearly demonstrate end-to-end engineering decisions and outcomes.
+- The profile is credible for AI-native hiring loops and technical collaboration.
 
 ---
 
-## Current Status (Baseline)
+## Operating Principles
 
-### Technical Background
+1. Threat model first.  
+Define allowed resources, blast radius, and unacceptable outcomes before implementation.
 
-* Senior Software Engineer
-* Strong JavaScript (frontend + backend)
-* Experience across:
+2. Deny by default.  
+Capabilities, filesystem, network, and credentials are restricted until explicitly allowed.
 
-  * Architecture
-  * Quality
-  * DevOps
-  * CI/CD
-  * UX
-  * Accessibility (A11y)
-* Python: working knowledge, not primary language
-* AI experience: usage and integration, not model ownership
+3. Everything is replayable.  
+Each run must produce traceable artifacts and reproducible context.
 
-### Strengths
+4. Evaluation before claims.  
+If behavior cannot be measured and compared, it is not complete.
 
-* Systems thinking
-* Production mindset
-* Cross-layer understanding
-* Engineering rigor
-
-### Gaps (Explicit)
-
-* No production agent systems shipped
-* No visible evaluation or observability work for AI
-* Python not yet primary
-* No public AI tooling artifacts
-* Profile reads as "AI-adjacent", not "AI-first"
-
-These gaps are acknowledged and intentional starting constraints.
+5. Small compounding steps.  
+Every work session should produce one concrete artifact and one clear next step.
 
 ---
 
-## Core Product Principles
+## Platform Progression Map
 
-1. **Agents are systems, not chats**
-   An agent must have: loop, tools, memory, termination, and evaluation.
-
-2. **Evaluation is the product**
-   If it cannot be measured or replayed, it is not done.
-
-3. **Few primitives, high leverage**
-   Prefer a small set of general skills over a long list of narrow tools.
-
-4. **Context discipline**
-   Treat context as scarce; offload to files/storage; summarize only when necessary.
-
-5. **Non-technical UX**
-   Composability and clarity are requirements, not nice-to-haves.
-
-6. **Framework-agnostic**
-   Understand loops/tooling/evals; choose the best tool per scenario. Be fluent with AI coding tools in real work.
+| Stage | Platform | Role in the roadmap |
+|---|---|---|
+| Start | Nanobot | Fastest path to hands-on agent operations and iteration discipline. |
+| Expand | OpenClaw | Broader deployable agent platform patterns and reusable architecture. |
+| Harden | AgentZero | High-capability OS-agent hardening, policy enforcement, and blast-radius control. |
+| Productivity | OpenCode | Async/background coding operations and artifact-driven automation workflows. |
 
 ---
 
-## Primary Focus: AI Agents
+## 2026–2027 Trend Alignment
 
-### Why Agents
+1. Tool protocol interoperability (MCP/connectors).  
+Design tools and integration boundaries so agents can consume external capabilities through standard protocols.
 
-AI Agents sit at the intersection of:
+2. Structured outputs and typed tool contracts.  
+Use schema-first I/O for predictable automation and easier regression testing.
 
-* Models
-* Systems
-* Evaluation
-* Infrastructure
-* Product behavior
+3. Background and async execution.  
+Treat long-running operations as first-class, auditable jobs with resumable artifacts.
 
-They force rigor in:
+4. Context and state quality.  
+Invest in memory relevance, compaction, and prompt-context hygiene to reduce drift and cost.
 
-* Decision-making
-* Memory
-* Tool use
-* Failure handling
-* Evaluation under uncertainty
-
-Agents are not demos. They are **systems**.
-
-### Scope of "Agents" in this Journey
-
-* Single-agent systems with measurable objectives
-* Tool-using agents (APIs, code execution, retrieval)
-* Memory architectures
-* Agent evaluation frameworks
-* Reliability, observability, and debugging of agent behavior
-* Workflow automation (triggers, state, human approvals, audit logs)
+5. Cost and performance governance.  
+Use model routing, budget controls, fallback strategies, and caching to balance quality and spend.
 
 ---
 
-## Competency Checklist
+## Iterative Operating Mode
 
-### Agent Runtime
+Work happens in available free slots, not fixed schedules.
 
-* Loop with explicit termination
-* Tool registry + schemas + error surfaces
-* Retries/backoff + rate-limit handling
-* Deterministic run artifacts (run_id, config snapshot, trace logs)
+Session rule:
 
-### Skills Design
+- Select the smallest unblocked task with high learning leverage.
+- Produce one concrete artifact (code, test, run report, doc update, or postmortem).
+- Record decision, result, and the next smallest step.
 
-* Clean, stable abstractions
-* Composability (skills chain without leaking complexity)
-* Non-technical docs/examples
-* Input/output schemas
-* Idempotency strategies
-* Logging/tracing hooks
+Progress metric:
 
-### Workflow Automation
-
-* Triggers, state, human approvals, audit logs
-* Integration adapters (real + mock for CRM, drive, chat)
-
-### AI Dev Environment Ownership
-
-* Templates + "golden paths"
-* Rules/patterns for AI coding assistants
-* Docs that let others ship fast
+- Consistent micro-delivery and documented learning over time.
 
 ---
 
-## The Two Spine Repos (Phase 1–2)
+## Public Artifact Standards
 
-### 1) `agent-evalkit` (core engineering proof)
-
-A minimal harness to:
-
-* Define tasks (JSONL) for agent workflows (research, enrichment, drafting, routing)
-* Run agents, capture **step traces**, tool calls, failures
-* Score outcomes and compare runs (regressions)
-
-### 2) `skills-kit` (composable primitives)
-
-A modular "Skills" library:
-
-* Each skill is a composable primitive with:
-  * Input schema
-  * Output schema
-  * Idempotency strategy
-  * Logging/tracing hooks
-  * Documentation for non-technical users
-* Provide adapters:
-  * Real integrations where possible
-  * **Mock adapters** (CRM, drive, chat) so the repo is runnable
+- A reviewer can understand objective, approach, and evidence quickly.
+- Each artifact includes what changed, why it changed, and how it was validated.
+- Claims are supported by traces, logs, metrics, tests, or reproducible runs.
 
 ---
 
-## Public Narrative & Personal Platform
+## Relationship with `plan.md`
 
-### Personal Domain
-
-Primary public hub:
-
-* **[https://marcosgilf.com](https://marcosgilf.com)**
-
-Purpose:
-
-* Track the AI Engineer journey publicly
-* Publish technical write-ups and experiments
-* Host long-form thinking that does not fit social media
-* Act as the canonical source of truth
-
-GitHub remains the execution layer. The website is the narrative layer.
-
-### LinkedIn Relationship (Single Source of Truth)
-
-LinkedIn is treated as a **distribution channel**, not the source of truth.
-
-Rules:
-
-* Canonical content lives on marcosgilf.com
-* LinkedIn posts reference or summarize canonical content
-* No divergence between profiles
-
-References:
-
-* [https://es.linkedin.com/in/marcosgilfernandez/en](https://es.linkedin.com/in/marcosgilfernandez/en)
-* [https://www.getmanfred.com/blog/writing-in-linkedin](https://www.getmanfred.com/blog/writing-in-linkedin)
-* [https://www.getmanfred.com/en/blog/de-scrappers-imposibles-a-apis-funcionales-la-aventura-de-manfred-con-linkedin](https://www.getmanfred.com/en/blog/de-scrappers-imposibles-a-apis-funcionales-la-aventura-de-manfred-con-linkedin)
+Detailed execution tracking lives in `plan.md`, using capability-based workstreams and explicit status markers.
 
 ---
 
-## Observability & Impact Tracking (Dogfooding)
+## Change Log
 
-The personal platform is also an **engineering playground**.
+### v1 (2026-01-23)
 
-### Objectives
+- Established initial AI Engineer transition direction.
+- Introduced phase-based execution structure and cadence guidance.
 
-* Measure reach and engagement
-* Practice production-grade observability
-* Apply infra thinking to personal work
+### v2 (2026-02-18)
 
-### Stack (Open Source)
-
-* **OpenTelemetry** — tracing and metrics
-* **Prometheus** — metrics collection
-* **Grafana** — dashboards and visualization
-
-### Metrics of Interest
-
-* Page visits and navigation paths
-* Time on content
-* Interaction depth (scroll, clicks)
-* Content performance over time
-* Correlation between published artifacts and inbound signals
-
-No third-party black-box analytics unless strictly necessary.
-
----
-
-## Execution Plan
-
-See [plan.md](plan.md) for the detailed execution roadmap with tracked steps.
-
-### Phase Summary
-
-| Phase | Focus | Timeline |
-|-------|-------|----------|
-| Phase 0 | Setup & infrastructure | Days 1–3 |
-| Phase 1 | Agentic engineering fundamentals (`agent-evalkit`) | Weeks 1–6 |
-| Phase 2 | Skills library + workflow automation (`skills-kit`) | Weeks 7–12 |
-| Phase 3 | AI dev environment ownership | Weeks 13–16 |
-| Phase 4 | Positioning & narrative | Weeks 17–20 |
-| Future | Core ML (deferred) | Post Week 20 |
-
-### Daily Operating Cadence (1 hour/day)
-
-* **40 min build**: one small slice (feature + test)
-* **10 min evaluate**: run suite, log deltas
-* **10 min document**: DEVLOG entry + one lesson learned
-
-### Key Deliverables
-
-* `agent-evalkit` — eval harness with step traces, tool calls, and regression tests
-* `skills-kit` — composable primitives with schemas, docs, and mock adapters
-* Golden template repo for team enablement
-* 2 canonical technical posts on marcosgilf.com
-
-### Future Phase — Core ML
-
-Deferred to build a strong foundation in production agent systems first:
-
-* Model training, fine-tuning, and evaluation
-* Research-adjacent engineering contributions
-* Multimodal systems
-
----
-
-## Output Standards (Public Artifacts)
-
-* A stranger can clone and run in <15 minutes
-* README includes: objective, how to run, metrics, failure analysis, roadmap
-* Code demonstrates production patterns (logging, retries, idempotency)
-
----
-
-## Constraints & Trade-offs
-
-* This path sacrifices short-term comfort for long-term leverage
-* JavaScript remains useful but is no longer the center
-* Speed is less important than correctness and depth
-* Many attempts will fail; failures are expected artifacts
-* Core ML work is explicitly deferred, not abandoned
-
----
-
-## Operating Rules
-
-* If a system cannot be evaluated, it is incomplete
-* If results cannot be reproduced, they do not count
-* If something feels "too easy", it is probably too shallow
-* No resume-driven development
-
----
-
-## Review Cadence
-
-* Monthly: reassess focus and learning gaps
-* Quarterly: evaluate whether artifacts match target roles
-* Annually: decide whether to narrow or pivot focus
-
----
-
-## Final Note
-
-This document is a **living system definition**.
-It will evolve as skills, constraints, and opportunities change.
-
-The goal is not to "learn AI".
-The goal is to **become an Applied AI Engineer others rely on**.
+- Preserved AI Engineer framing as the primary identity.
+- Clarified AI Agents as the starting specialization path.
+- Added explicit 2026–2027 scope and trend alignment.
+- Added iterative operating mode based on available free slots.
+- Added platform progression map from Nanobot to broader platforms.
+- Merged security and rigor principles from `instructions-v2.md`.
+- Added document version control and inline change history.

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -1,188 +1,184 @@
-# Plan — Applied AI Engineer Execution Roadmap
+# Plan — AI Engineer Execution Roadmap
 
-Optimized for **1 hour/day** and aligned to Applied AI responsibilities: agents + skills + workflow automation + AI dev environment.
+## Document Control
 
-See [ai-engineer.md](ai-engineer.md) for context, goals, and principles.
-
----
-
-## Phase 0 — Setup (Days 1–3)
-
-**Goal:** Remove friction and establish infrastructure.
-
-| Step | Description | Completed |
-|------|-------------|-----------|
-| 0.1 | Create repos: `agent-evalkit`, `skills-kit`, `marcosgilf.com` | `false` |
-| 0.2 | Standard tooling: `uv` (or poetry), ruff, pytest, pre-commit, GitHub Actions | `false` |
-| 0.3 | Start `DEVLOG.md` (daily log) | `false` |
-
-**Exit criteria:** CI green; "hello run" produces `runs/<run_id>/`.
+| Version | Date | Source | Notes |
+|---|---|---|---|
+| v1 | 2026-01-23 | Commit `c22992c` (`docs: ai engineer plan`) | Initial phase-based roadmap with fixed cadence constraints. |
+| v2 | 2026-02-18 | `instructions-v2.md`, `plan-v2.md`, nanobot specs (`iac.md`, `llm-router.md`, `memory-manager.md`, `wodbuster-booker.md`) | Converts roadmap to iterative execution, keeps AI Engineer identity, and makes Nanobot an active starter track within a broader multi-platform plan. |
 
 ---
 
-## Phase 1 — Agentic Engineering Fundamentals (Weeks 1–6)
+## Plan Status Vocabulary
 
-**Goal:** Build and evaluate a tool-using agent loop (not a demo).
+Use only these statuses:
 
-### Week 1: Skeleton + Run Artifacts
-
-| Step | Description | Completed |
-|------|-------------|-----------|
-| 1.1 | CLI: `run --config ...` | `false` |
-| 1.2 | Create `runs/<run_id>/` with config snapshot + placeholder report | `false` |
-| 1.3 | Smoke tests + CI | `false` |
-
-### Week 2: Task Schema + Scoring v0
-
-| Step | Description | Completed |
-|------|-------------|-----------|
-| 2.1 | JSONL tasks: prompt + expected + tags + allowed_tools | `false` |
-| 2.2 | JSONL results: output + score + error + latency + trace_path | `false` |
-| 2.3 | Metrics report: overall + per-tag | `false` |
-
-### Week 3: Tooling + Agent Loop v0
-
-| Step | Description | Completed |
-|------|-------------|-----------|
-| 3.1 | Tool registry + schemas | `false` |
-| 3.2 | Tools: calculator + local file search + write file | `false` |
-| 3.3 | Termination: max steps + explicit done | `false` |
-
-### Week 4: Observability + Replay
-
-| Step | Description | Completed |
-|------|-------------|-----------|
-| 4.1 | Structured logs per step/tool call | `false` |
-| 4.2 | Save full trace per task | `false` |
-| 4.3 | Replay from stored artifacts | `false` |
-
-### Week 5: Failure Taxonomy + Fixes
-
-| Step | Description | Completed |
-|------|-------------|-----------|
-| 5.1 | Categorize failures (tool choice, args, loop, hallucination) | `false` |
-| 5.2 | Implement 2 fixes | `false` |
-| 5.3 | Before/after metrics | `false` |
-
-### Week 6: Regression Testing
-
-| Step | Description | Completed |
-|------|-------------|-----------|
-| 6.1 | Run comparison command | `false` |
-| 6.2 | Alert on score deltas; list broken tasks | `false` |
-
-**Exit criteria:** `agent-evalkit` is inspectable and measurable.
+- `Done` — objective completed with evidence.
+- `In Progress` — currently active and unblocked.
+- `Blocked` — cannot advance without resolving an external dependency.
+- `Queued` — intentionally deferred, ready for activation.
 
 ---
 
-## Phase 2 — Skills Library + Workflow Automation (Weeks 7–12)
+## Execution Model (Iterative)
 
-**Goal:** Build modular, composable skills and autonomous workflows.
+This plan is executed in free time slots, not fixed schedules.
 
-### Weeks 7–8: `skills-kit` v0
+Session operating rule:
 
-| Step | Description | Completed |
-|------|-------------|-----------|
-| 7.1 | Write a "Skill spec" (schema, idempotency, logs, examples) | `false` |
-| 7.2 | Implement 6–10 skills (primitives) with mock adapters | `false` |
+1. Pick the smallest unblocked next task.
+2. End the session with one concrete artifact.
+3. Log decision, result, and next smallest step.
 
-Example skills:
-- `find_company_info`, `enrich_contact`, `draft_email`
-- `summarize_thread`, `create_crm_record`, `update_pipeline_stage`
-
-### Weeks 9–10: Composition + Non-Technical UX
-
-| Step | Description | Completed |
-|------|-------------|-----------|
-| 9.1 | Skill cookbook docs (copy/paste examples) | `false` |
-| 9.2 | Composer interface: YAML workflows OR CLI wizard | `false` |
-| 9.3 | Evals for composed workflows (multi-step) | `false` |
-
-### Weeks 11–12: Workflow Automation
-
-| Step | Description | Completed |
-|------|-------------|-----------|
-| 11.1 | Build workflow 1: Lead research → enrichment → CRM update → notification | `false` |
-| 11.2 | Build workflow 2: Proposal draft → review gate → send/log | `false` |
-| 11.3 | Add audit logs + human approval steps | `false` |
-
-**Exit criteria:** Realistic automation demo that runs end-to-end and is measurable.
+Valid artifacts include code change, test case, run report, trace sample, design note, or postmortem entry.
 
 ---
 
-## Phase 3 — AI Dev Environment Ownership (Weeks 13–16)
+## Current Program Context
 
-**Goal:** Prove you can enable a team to ship fast.
+Primary identity:
 
-### Golden Template Repo
+- AI Engineer.
 
-| Step | Description | Completed |
-|------|-------------|-----------|
-| 13.1 | Logging/tracing setup | `false` |
-| 13.2 | Eval harness wiring | `false` |
-| 13.3 | Tool scaffolding | `false` |
-| 13.4 | Safe defaults configuration | `false` |
+Current starting domain:
 
-### Documentation
+- AI Agents.
 
-| Step | Description | Completed |
-|------|-------------|-----------|
-| 14.1 | AI coding tools rules and usage patterns (Cursor, Claude Code, etc.) | `false` |
-| 14.2 | Production readiness checklists (retries, idempotency, secrets, rate limits, monitoring) | `false` |
+Current active platform:
 
-**Exit criteria:** Templates + docs that a teammate could follow to build agent workflows.
+- Nanobot, selected because it has the lowest learning curve and immediate deployability.
+
+Roadmap boundary:
+
+- Nanobot is a starting track, not the full scope of the plan.
 
 ---
 
-## Phase 4 — Positioning (Weeks 17–20)
+## Nanobot Starter Track
 
-**Goal:** Convert artifacts into hiring-loop-ready narrative.
+**Status:** `In Progress`
 
-### Content
+**Objective:** Build practical agent engineering depth through real deployment, skill operations, and reliability improvements.
 
-| Step | Description | Completed |
-|------|-------------|-----------|
-| 17.1 | Post: "Composable Skills for automation: design + tradeoffs" | `false` |
-| 17.2 | Post: "Evaluating tool-using agents: failure modes + regression tests" | `false` |
-| 17.3 | Portfolio page with demos, metrics, architecture diagrams | `false` |
+**Current evidence artifacts:**
 
-### Interview Preparation
+- IaC and deployment workflows documented and operational.
+- Active feature specs: `iac`, `llm-router`, `memory-manager`, `wodbuster-booker`.
+- Test and lint baseline currently passing in the nanobot project.
 
-| Step | Description | Completed |
-|------|-------------|-----------|
-| 18.1 | System design deep dive document | `false` |
-| 18.2 | Postmortem of one failure | `false` |
-| 18.3 | Scaling plan (cost, caching, reliability) | `false` |
+**Cross-over checkpoints to broader platforms:**
 
-**Exit criteria:** A reviewer sees direct fit to Applied AI roles in <10 minutes.
+1. When policy and sandbox interfaces are stable in Nanobot patterns, start OpenClaw integration baseline.
+2. When risky-action controls and audit style are stable, start AgentZero hardening exercises.
+3. When async operational flow is repeatable, start OpenCode background execution track.
 
 ---
 
-## Future Phase — Core ML (Post Week 20)
+## Workstream A: Agent Runtime & Tool Use
 
-Deferred objectives to tackle after establishing production agent expertise:
+- **Objective:** Build robust runtime behavior for tool-using agents with explicit contracts and termination boundaries.
+- **Current status:** `In Progress`
+- **Next 3 smallest tasks:**
+1. Define a normalized tool contract template (name, schema, guardrails, expected output).
+2. Add one trace example that captures a full tool decision cycle.
+3. Document one failure mode where tool selection was incorrect and the correction.
+- **Exit criteria:** Runtime behavior is inspectable, reproducible, and consistently schema-driven.
+- **Evidence artifacts:** Tool contract docs, trace samples, failure-analysis notes, regression examples.
 
-| Step | Description | Completed |
-|------|-------------|-----------|
-| F.1 | Model training fundamentals (PyTorch) | `false` |
-| F.2 | Fine-tuning workflows | `false` |
-| F.3 | Model evaluation frameworks | `false` |
-| F.4 | Multimodal systems exploration | `false` |
+## Workstream B: Evaluation & Regression
+
+- **Objective:** Make behavior measurable and comparable across changes.
+- **Current status:** `In Progress`
+- **Next 3 smallest tasks:**
+1. Define minimum eval task format for current agent behaviors.
+2. Add one scorer for structured output validity.
+3. Produce one before/after comparison artifact for a real fix.
+- **Exit criteria:** Every significant behavior change can be validated through repeatable evaluation outputs.
+- **Evidence artifacts:** Eval task files, scorer definitions, comparison reports, regression logs.
+
+## Workstream C: Secure Deployment & Policies
+
+- **Objective:** Apply threat-model-first and deny-by-default controls to agent operations.
+- **Current status:** `In Progress`
+- **Next 3 smallest tasks:**
+1. Write a lightweight threat model template for each automation flow.
+2. Define an allowlist policy draft for tool/network/filesystem access.
+3. Add one auditable denied-action example with rationale.
+- **Exit criteria:** Critical flows run under explicit policy boundaries with auditable decisions.
+- **Evidence artifacts:** Threat model docs, policy files, audit event samples, incident notes.
+
+## Workstream D: Async/Background Agent Operations
+
+- **Objective:** Enable long-running and deferred tasks with clear artifact outputs.
+- **Current status:** `In Progress`
+- **Next 3 smallest tasks:**
+1. Standardize background run output layout (logs, traces, result summary).
+2. Define one retry and resumption rule for interrupted jobs.
+3. Add one notification format for background completion/failure.
+- **Exit criteria:** Background tasks can run safely, be inspected afterward, and be resumed predictably.
+- **Evidence artifacts:** Run directories, retry logs, completion notifications, operator runbook snippets.
+
+## Workstream E: Narrative & Portfolio
+
+- **Objective:** Convert engineering work into clear public proof of AI engineering capability.
+- **Current status:** `In Progress`
+- **Next 3 smallest tasks:**
+1. Publish one architecture note that links goal, implementation, and evidence.
+2. Publish one postmortem with root cause and corrective action.
+3. Update portfolio index with latest artifact links and validation evidence.
+- **Exit criteria:** External reviewers can evaluate depth, rigor, and delivery quality quickly.
+- **Evidence artifacts:** Public write-ups, architecture diagrams, postmortems, portfolio updates.
 
 ---
 
-## Weekly Rhythm (1h/day)
+## Expansion Tracks
 
-| Day | Focus |
-|-----|-------|
-| Mon–Thu | Implement + tests |
-| Fri | Evaluation + cleanup + README updates |
-| Weekend (optional) | 1 deeper workflow session |
+| Platform | Status | Why it matters | First activation task |
+|---|---|---|---|
+| OpenClaw | `Queued` | Generalize deployable agent platform patterns beyond Nanobot. | Stand up a minimal runtime with one policy-controlled tool path. |
+| AgentZero | `Queued` | Practice hardening for high-capability OS-agent behavior. | Build strict policy profile and test denied destructive actions. |
+| OpenCode | `Queued` | Operationalize async coding workflows and artifact-first delivery. | Run one background task and store reproducible artifacts end-to-end. |
 
-## Daily Cadence
+---
 
-| Time | Activity |
-|------|----------|
-| 40 min | Build: one small slice (feature + test) |
-| 10 min | Evaluate: run suite, log deltas |
-| 10 min | Document: DEVLOG entry + one lesson learned |
+## How to Pick Next Task
+
+1. Start from active workstreams in this priority order: blocked fixes, reliability risks, evaluation gaps, then expansion tasks.
+2. If current task is blocked, switch immediately to the next smallest unblocked task in another workstream.
+3. Prefer tasks that improve both capability and evidence quality.
+4. Avoid tasks that cannot produce a concrete artifact in one work session.
+5. End by recording the next smallest step so restart cost stays low.
+
+---
+
+## Learning Signals
+
+Track progress by capability gains instead of elapsed time:
+
+- **System design quality:** clearer boundaries, fewer hidden assumptions.
+- **Reliability quality:** fewer flaky outcomes, better error handling and recovery.
+- **Security quality:** stronger least-privilege defaults and explicit risk handling.
+- **Evaluation rigor:** better testability, comparability, and regression confidence.
+- **Automation quality:** more repeatable workflows with better operational visibility.
+
+If a session does not improve at least one signal, adjust task selection criteria.
+
+---
+
+## Change Log
+
+### v1 (2026-01-23)
+
+- Defined initial roadmap as time-boxed phases.
+- Emphasized agent systems, skills, and public narrative deliverables.
+
+### v2 (2026-02-18)
+
+- Removed fixed schedule constraints and switched to iterative execution.
+- Preserved AI Engineer framing as the primary identity.
+- Set AI Agents as the starting specialization path.
+- Added capability-based workstreams with explicit status vocabulary.
+- Added Nanobot starter track as active, with cross-over checkpoints.
+- Added queued expansion tracks for OpenClaw, AgentZero, and OpenCode.
+- Added task selection rules and learning-signal feedback loop.
+- Added document version control and inline change history.

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,10 +13,10 @@
         "@astrojs/netlify": "^6.6.4",
         "@astrojs/rss": "^4.0.15",
         "@astrojs/sitemap": "^3.7.0",
-        "astro": "^5.17.1"
+        "astro": "^5.17.2"
       },
       "devDependencies": {
-        "@biomejs/biome": "^2.3.14",
+        "@biomejs/biome": "^2.4.2",
         "@commitlint/cli": "^20.4.1",
         "@commitlint/config-conventional": "^20.4.1",
         "@vitest/coverage-v8": "^4.0.18",
@@ -242,9 +242,9 @@
       }
     },
     "node_modules/@biomejs/biome": {
-      "version": "2.3.14",
-      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.3.14.tgz",
-      "integrity": "sha512-QMT6QviX0WqXJCaiqVMiBUCr5WRQ1iFSjvOLoTk6auKukJMvnMzWucXpwZB0e8F00/1/BsS9DzcKgWH+CLqVuA==",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.4.2.tgz",
+      "integrity": "sha512-vVE/FqLxNLbvYnFDYg3Xfrh1UdFhmPT5i+yPT9GE2nTUgI4rkqo5krw5wK19YHBd7aE7J6r91RRmb8RWwkjy6w==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "bin": {
@@ -258,20 +258,20 @@
         "url": "https://opencollective.com/biome"
       },
       "optionalDependencies": {
-        "@biomejs/cli-darwin-arm64": "2.3.14",
-        "@biomejs/cli-darwin-x64": "2.3.14",
-        "@biomejs/cli-linux-arm64": "2.3.14",
-        "@biomejs/cli-linux-arm64-musl": "2.3.14",
-        "@biomejs/cli-linux-x64": "2.3.14",
-        "@biomejs/cli-linux-x64-musl": "2.3.14",
-        "@biomejs/cli-win32-arm64": "2.3.14",
-        "@biomejs/cli-win32-x64": "2.3.14"
+        "@biomejs/cli-darwin-arm64": "2.4.2",
+        "@biomejs/cli-darwin-x64": "2.4.2",
+        "@biomejs/cli-linux-arm64": "2.4.2",
+        "@biomejs/cli-linux-arm64-musl": "2.4.2",
+        "@biomejs/cli-linux-x64": "2.4.2",
+        "@biomejs/cli-linux-x64-musl": "2.4.2",
+        "@biomejs/cli-win32-arm64": "2.4.2",
+        "@biomejs/cli-win32-x64": "2.4.2"
       }
     },
     "node_modules/@biomejs/cli-darwin-arm64": {
-      "version": "2.3.14",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.3.14.tgz",
-      "integrity": "sha512-UJGPpvWJMkLxSRtpCAKfKh41Q4JJXisvxZL8ChN1eNW3m/WlPFJ6EFDCE7YfUb4XS8ZFi3C1dFpxUJ0Ety5n+A==",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.4.2.tgz",
+      "integrity": "sha512-3pEcKCP/1POKyaZZhXcxFl3+d9njmeAihZ17k8lL/1vk+6e0Cbf0yPzKItFiT+5Yh6TQA4uKvnlqe0oVZwRxCA==",
       "cpu": [
         "arm64"
       ],
@@ -286,9 +286,9 @@
       }
     },
     "node_modules/@biomejs/cli-darwin-x64": {
-      "version": "2.3.14",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.3.14.tgz",
-      "integrity": "sha512-PNkLNQG6RLo8lG7QoWe/hhnMxJIt1tEimoXpGQjwS/dkdNiKBLPv4RpeQl8o3s1OKI3ZOR5XPiYtmbGGHAOnLA==",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.4.2.tgz",
+      "integrity": "sha512-P7hK1jLVny+0R9UwyGcECxO6sjETxfPyBm/1dmFjnDOHgdDPjPqozByunrwh4xPKld8sxOr5eAsSqal5uKgeBg==",
       "cpu": [
         "x64"
       ],
@@ -303,9 +303,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-arm64": {
-      "version": "2.3.14",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.3.14.tgz",
-      "integrity": "sha512-KT67FKfzIw6DNnUNdYlBg+eU24Go3n75GWK6NwU4+yJmDYFe9i/MjiI+U/iEzKvo0g7G7MZqoyrhIYuND2w8QQ==",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.4.2.tgz",
+      "integrity": "sha512-DI3Mi7GT2zYNgUTDEbSjl3e1KhoP76OjQdm8JpvZYZWtVDRyLd3w8llSr2TWk1z+U3P44kUBWY3X7H9MD1/DGQ==",
       "cpu": [
         "arm64"
       ],
@@ -320,9 +320,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-arm64-musl": {
-      "version": "2.3.14",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.3.14.tgz",
-      "integrity": "sha512-LInRbXhYujtL3sH2TMCH/UBwJZsoGwfQjBrMfl84CD4hL/41C/EU5mldqf1yoFpsI0iPWuU83U+nB2TUUypWeg==",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.4.2.tgz",
+      "integrity": "sha512-/x04YK9+7erw6tYEcJv9WXoBHcULI/wMOvNdAyE9S3JStZZ9yJyV67sWAI+90UHuDo/BDhq0d96LDqGlSVv7WA==",
       "cpu": [
         "arm64"
       ],
@@ -337,9 +337,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-x64": {
-      "version": "2.3.14",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.3.14.tgz",
-      "integrity": "sha512-ZsZzQsl9U+wxFrGGS4f6UxREUlgHwmEfu1IrXlgNFrNnd5Th6lIJr8KmSzu/+meSa9f4rzFrbEW9LBBA6ScoMA==",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.4.2.tgz",
+      "integrity": "sha512-GK2ErnrKpWFigYP68cXiCHK4RTL4IUWhK92AFS3U28X/nuAL5+hTuy6hyobc8JZRSt+upXt1nXChK+tuHHx4mA==",
       "cpu": [
         "x64"
       ],
@@ -354,9 +354,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-x64-musl": {
-      "version": "2.3.14",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.3.14.tgz",
-      "integrity": "sha512-KQU7EkbBBuHPW3/rAcoiVmhlPtDSGOGRPv9js7qJVpYTzjQmVR+C9Rfcz+ti8YCH+zT1J52tuBybtP4IodjxZQ==",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.4.2.tgz",
+      "integrity": "sha512-wbBmTkeAoAYbOQ33f6sfKG7pcRSydQiF+dTYOBjJsnXO2mWEOQHllKlC2YVnedqZFERp2WZhFUoO7TNRwnwEHQ==",
       "cpu": [
         "x64"
       ],
@@ -371,9 +371,9 @@
       }
     },
     "node_modules/@biomejs/cli-win32-arm64": {
-      "version": "2.3.14",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.3.14.tgz",
-      "integrity": "sha512-+IKYkj/pUBbnRf1G1+RlyA3LWiDgra1xpS7H2g4BuOzzRbRB+hmlw0yFsLprHhbbt7jUzbzAbAjK/Pn0FDnh1A==",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.4.2.tgz",
+      "integrity": "sha512-k2uqwLYrNNxnaoiW3RJxoMGnbKda8FuCmtYG3cOtVljs3CzWxaTR+AoXwKGHscC9thax9R4kOrtWqWN0+KdPTw==",
       "cpu": [
         "arm64"
       ],
@@ -388,9 +388,9 @@
       }
     },
     "node_modules/@biomejs/cli-win32-x64": {
-      "version": "2.3.14",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.3.14.tgz",
-      "integrity": "sha512-oizCjdyQ3WJEswpb3Chdngeat56rIdSYK12JI3iI11Mt5T5EXcZ7WLuowzEaFPNJ3zmOQFliMN8QY1Pi+qsfdQ==",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.4.2.tgz",
+      "integrity": "sha512-9ma7C4g8Sq3cBlRJD2yrsHXB1mnnEBdpy7PhvFrylQWQb4PoyCmPucdX7frvsSBQuFtIiKCrolPl/8tCZrKvgQ==",
       "cpu": [
         "x64"
       ],
@@ -5139,9 +5139,9 @@
       }
     },
     "node_modules/astro": {
-      "version": "5.17.1",
-      "resolved": "https://registry.npmjs.org/astro/-/astro-5.17.1.tgz",
-      "integrity": "sha512-oD3tlxTaVWGq/Wfbqk6gxzVRz98xa/rYlpe+gU2jXJMSD01k6sEDL01ZlT8mVSYB/rMgnvIOfiQQ3BbLdN237A==",
+      "version": "5.17.2",
+      "resolved": "https://registry.npmjs.org/astro/-/astro-5.17.2.tgz",
+      "integrity": "sha512-7jnMqGo53hOQNwo1N/wqeOvUp8wwW/p+DeerSjSkHNx8L/1mhy6P7rVo7EhdmF8DpKqw0tl/B5Fx1WcIzg1ysA==",
       "license": "MIT",
       "dependencies": {
         "@astrojs/compiler": "^2.13.0",
@@ -5167,7 +5167,7 @@
         "dlv": "^1.1.3",
         "dset": "^3.1.4",
         "es-module-lexer": "^1.7.0",
-        "esbuild": "^0.25.0",
+        "esbuild": "^0.27.0",
         "estree-walker": "^3.0.3",
         "flattie": "^1.1.1",
         "fontace": "~0.4.0",
@@ -5222,6 +5222,463 @@
       },
       "optionalDependencies": {
         "sharp": "^0.34.0"
+      }
+    },
+    "node_modules/astro/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
+      "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/astro/node_modules/@esbuild/android-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
+      "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/astro/node_modules/@esbuild/android-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
+      "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/astro/node_modules/@esbuild/android-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
+      "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/astro/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
+      "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/astro/node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
+      "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/astro/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/astro/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
+      "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/astro/node_modules/@esbuild/linux-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
+      "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/astro/node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
+      "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/astro/node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
+      "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/astro/node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
+      "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/astro/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
+      "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/astro/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
+      "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/astro/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
+      "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/astro/node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
+      "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/astro/node_modules/@esbuild/linux-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
+      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/astro/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/astro/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/astro/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/astro/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/astro/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
+      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/astro/node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
+      "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/astro/node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
+      "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/astro/node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
+      "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/astro/node_modules/@esbuild/win32-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
+      "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/astro/node_modules/esbuild": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
+      "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.3",
+        "@esbuild/android-arm": "0.27.3",
+        "@esbuild/android-arm64": "0.27.3",
+        "@esbuild/android-x64": "0.27.3",
+        "@esbuild/darwin-arm64": "0.27.3",
+        "@esbuild/darwin-x64": "0.27.3",
+        "@esbuild/freebsd-arm64": "0.27.3",
+        "@esbuild/freebsd-x64": "0.27.3",
+        "@esbuild/linux-arm": "0.27.3",
+        "@esbuild/linux-arm64": "0.27.3",
+        "@esbuild/linux-ia32": "0.27.3",
+        "@esbuild/linux-loong64": "0.27.3",
+        "@esbuild/linux-mips64el": "0.27.3",
+        "@esbuild/linux-ppc64": "0.27.3",
+        "@esbuild/linux-riscv64": "0.27.3",
+        "@esbuild/linux-s390x": "0.27.3",
+        "@esbuild/linux-x64": "0.27.3",
+        "@esbuild/netbsd-arm64": "0.27.3",
+        "@esbuild/netbsd-x64": "0.27.3",
+        "@esbuild/openbsd-arm64": "0.27.3",
+        "@esbuild/openbsd-x64": "0.27.3",
+        "@esbuild/openharmony-arm64": "0.27.3",
+        "@esbuild/sunos-x64": "0.27.3",
+        "@esbuild/win32-arm64": "0.27.3",
+        "@esbuild/win32-ia32": "0.27.3",
+        "@esbuild/win32-x64": "0.27.3"
       }
     },
     "node_modules/async": {

--- a/package.json
+++ b/package.json
@@ -38,10 +38,10 @@
     "@astrojs/netlify": "^6.6.4",
     "@astrojs/rss": "^4.0.15",
     "@astrojs/sitemap": "^3.7.0",
-    "astro": "^5.17.1"
+    "astro": "^5.17.2"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.3.14",
+    "@biomejs/biome": "^2.4.2",
     "@commitlint/cli": "^20.4.1",
     "@commitlint/config-conventional": "^20.4.1",
     "@vitest/coverage-v8": "^4.0.18",

--- a/specs/main-functionalities-astro.md
+++ b/specs/main-functionalities-astro.md
@@ -1,69 +1,305 @@
-# Main Functionalities Specification
+# Astro Blog – Replication Spec
 
-## Project Overview
+Generic specification to replicate this project setup from scratch using an AI agent.
+All personal content, copy, images and domain-specific values are intentionally omitted.
 
-This is a personal blog website built with **Astro** framework, serving as Marcos Gil's personal space on the internet. The site is designed as a modern, static blog with MDX support and optimized for performance.
+---
 
-### Key Information
-- **Owner**: Marcos Gil (marcosgilf.com)
-- **Repository**: https://github.com/marcosgilf/blog
-- **Site URL**: https://www.marcosgilf.com
-- **Framework**: Astro v5.x
-- **Deployment**: Netlify
-- **License**: MIT
+## 1. Technology Stack
 
-## Core Functionalities
+| Layer | Tool | Version hint |
+|---|---|---|
+| Framework | Astro | 5.x |
+| Language | TypeScript (ESM, `"type": "module"`) | — |
+| Content | MDX + Astro Content Collections | — |
+| Adapter | `@astrojs/netlify` (SSR `output: 'server'`) | — |
+| Integrations | `@astrojs/mdx`, `@astrojs/sitemap`, `@astrojs/rss` | — |
+| Linter / Formatter | Biome | 2.x |
+| Testing | Vitest + `@vitest/coverage-v8` | — |
+| Git hooks | Husky + lint-staged + commitlint | — |
+| Dep checker | npm-check-updates (`ncu`) | — |
+| IaC | Terraform (Netlify provider, Grafana provider) | ≥ 1.6 |
+| CI/CD | GitHub Actions → Netlify | — |
+| Node | LTS (see `.nvmrc`, currently `v22`) | — |
+| Package manager | npm | — |
 
-### 1. Static Site Generation
-- **Technology**: Astro framework with static site generation
-- **Build Command**: `npm run build`
-- **Output**: Static files in `./dist/` directory
-- **Development Server**: `npm run dev` (localhost:4321)
+---
 
-### 2. Blog System
-- **Content Management**: File-based content system using Astro Content Collections
-- **Content Location**: `src/content/blog/`
-- **Supported Formats**: Markdown (.md) and MDX (.mdx)
-- **Content Schema**: Validated frontmatter with required fields:
-  - `title` (string, required)
-  - `description` (string, required)
-  - `pubDate` (date, required)
-  - `updatedDate` (date, optional)
-  - `heroImage` (string, optional)
+## 2. Directory Structure
 
-### 3. Page Structure
-- **Home Page** (`/`): Personal introduction with profile image and navigation
-- **Blog Index** (`/blog`): Lists all blog posts
-- **Individual Blog Posts** (`/blog/[slug]`): Dynamic routing for blog content
-- **About Page** (`/about`): Personal information page
-- **RSS Feed** (`/rss.xml`): Automated RSS feed generation
+```
+.
+├── .github/workflows/       # CI, deploy, deploy-preview, dns-drift-check
+├── .husky/pre-commit         # Git hook
+├── .lintstagedrc.cjs          # lint-staged config
+├── .nvmrc                     # Node version
+├── .env.example               # Env vars template (committed)
+├── .env.development           # Dev env defaults (committed)
+├── .env                       # Local overrides (gitignored)
+├── .env.production            # Production secrets (gitignored)
+├── AGENTS.md                  # Agent/contributor notes
+├── astro.config.mjs           # Astro config
+├── biome.json                 # Biome linter/formatter config
+├── commitlint.config.js       # Conventional commits config
+├── vitest.config.js           # Vitest config (uses Astro's getViteConfig)
+├── tsconfig.json              # TypeScript config (extends astro/tsconfigs/base)
+├── package.json
+├── infra/
+│   ├── netlify/               # Terraform: DNS zone + env vars
+│   └── grafana/               # Terraform: Grafana dashboards
+├── public/                    # Static assets (fonts, images, favicon)
+│   └── fonts/
+├── specs/                     # Specification documents
+├── src/
+│   ├── consts.ts              # SITE_TITLE, SITE_DESCRIPTION exports
+│   ├── env.d.ts               # Astro env type reference
+│   ├── components/            # Astro components (+ co-located .test.js files)
+│   ├── content/
+│   │   ├── config.ts          # Content collection schema (Zod)
+│   │   └── blog/              # Markdown/MDX blog posts
+│   ├── layouts/               # Page layout templates
+│   ├── pages/
+│   │   ├── index.astro        # Home
+│   │   ├── about.astro        # About
+│   │   ├── rss.xml.js         # RSS feed
+│   │   ├── blog/
+│   │   │   ├── index.astro    # Blog listing
+│   │   │   └── [...slug].astro # Dynamic blog post route
+│   │   └── api/
+│   │       └── track.ts       # Server-side analytics endpoint (prerender: false)
+│   ├── styles/
+│   │   └── global.css
+│   └── utils/                 # Utility functions (+ co-located .test.js/.test.ts files)
+└── dist/                      # Build output (gitignored)
+```
 
-### 4. Component Architecture
-**Core Components** (located in `src/components/`):
-- `BaseHead.astro`: HTML head metadata and SEO
-- `Header.astro`: Site navigation header
-- `Footer.astro`: Site footer
-- `FormattedDate.astro`: Date formatting utility
-- `HeaderLink.astro`: Navigation link component
-- `SocialIcons.astro`: Social media icons
+---
 
-**Layout Components** (located in `src/layouts/`):
-- `BlogPost.astro`: Template for individual blog posts
+## 3. Configuration Files
 
-### 5. SEO and Performance Features
-- **Sitemap Generation**: Automatic sitemap.xml creation via @astrojs/sitemap
-- **RSS Feed**: Automated RSS feed for blog posts
-- **Meta Tags**: Proper HTML meta tags for SEO
-- **Static Assets**: Optimized static asset handling in `public/` directory
+### 3.1 `astro.config.mjs`
 
-### 6. Development Features
-- **TypeScript Support**: Full TypeScript integration
-- **Hot Module Replacement**: Development server with HMR
-- **Content Collections**: Type-safe content management
-- **Component Testing**: Vitest for unit testing
+```js
+import mdx from '@astrojs/mdx';
+import netlify from '@astrojs/netlify';
+import sitemap from '@astrojs/sitemap';
+import { defineConfig } from 'astro/config';
+import { loadEnv } from 'vite';
 
-### 7. Content Collections Schema
-```typescript
+const { SITE_URL } = loadEnv(process.env.NODE_ENV ?? '', process.cwd(), '');
+
+export default defineConfig({
+  output: 'server',
+  adapter: netlify(),
+  site: SITE_URL,
+  integrations: [mdx(), sitemap()],
+});
+```
+
+### 3.2 `tsconfig.json`
+
+```jsonc
+{
+  "extends": "astro/tsconfigs/base",
+  "compilerOptions": {
+    "module": "esnext",
+    "strictNullChecks": true,
+    "target": "es6"
+  }
+}
+```
+
+### 3.3 `biome.json`
+
+```jsonc
+{
+  "$schema": "https://biomejs.dev/schemas/2.x/schema.json",
+  "vcs": { "enabled": true, "clientKind": "git", "useIgnoreFile": true },
+  "files": {
+    "ignoreUnknown": true,
+    "includes": ["**", "!**/node_modules", "!**/coverage", "!**/dist", "!**/.history"]
+  },
+  "formatter": {
+    "enabled": true,
+    "lineWidth": 100,
+    "indentStyle": "space",
+    "indentWidth": 2
+  },
+  "assist": { "actions": { "source": { "organizeImports": "on" } } },
+  "linter": { "enabled": true, "rules": { "recommended": true } },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "single",
+      "arrowParentheses": "asNeeded",
+      "trailingCommas": "all",
+      "semicolons": "always"
+    }
+  },
+  "json": { "formatter": { "trailingCommas": "none" } },
+  "overrides": [
+    {
+      "includes": ["**/*.astro"],
+      "linter": { "rules": { "correctness": { "noUnusedVariables": "off", "noUnusedImports": "off" } } }
+    },
+    {
+      "includes": ["**/*.css"],
+      "linter": { "rules": { "complexity": { "noImportantStyles": "off" } } }
+    }
+  ]
+}
+```
+
+### 3.4 `vitest.config.js`
+
+```js
+import { getViteConfig } from 'astro/config';
+
+export default getViteConfig({
+  test: {},
+});
+```
+
+### 3.5 `commitlint.config.js`
+
+```js
+module.exports = {
+  extends: ['@commitlint/config-conventional'],
+};
+```
+
+### 3.6 `.lintstagedrc.cjs`
+
+```js
+module.exports = {
+  '*.{js,ts,json,md,mdx,astro,css}': ['biome check --write --no-errors-on-unmatched'],
+};
+```
+
+### 3.7 `.husky/pre-commit`
+
+```sh
+npx lint-staged
+npm run dependencies:check || (echo "❌ To upgrade package.json easier 🆙 npm run dependencies:update"; false)
+```
+
+### 3.8 `.nvmrc`
+
+```
+v22
+```
+
+### 3.9 `.gitignore`
+
+```gitignore
+dist/
+coverage/
+.astro/
+node_modules/
+npm-debug.log*
+.env
+.env.local
+.env.production
+.env.*.local
+# .env.development and .env.example are committed (safe defaults / docs)
+.DS_Store
+.terraform/
+*.tfstate
+*.tfstate.backup
+*.tfvars
+!*.tfvars.example
+.netlify
+```
+
+### 3.10 `.env.example`
+
+Template with all environment variables and placeholder values. Committed to the repo.
+
+```env
+# ── Site ──────────────────────────────────────────
+SITE_URL=https://YOUR_DOMAIN
+SITE_TITLE=Your Site Title
+SITE_DESCRIPTION=Your site description
+
+# ── Analytics (InfluxDB) ─────────────────────────
+INFLUX_URL=https://your-influxdb-instance
+INFLUX_TOKEN=your-influx-token
+INFLUX_ORG=your-org
+INFLUX_BUCKET=your-bucket
+```
+
+### 3.11 `.env.development`
+
+Development defaults. Committed (no secrets).
+
+```env
+SITE_URL=http://localhost:4321
+SITE_TITLE=Your Title (dev)
+SITE_DESCRIPTION=Your description – development
+INFLUX_URL=
+INFLUX_TOKEN=
+INFLUX_ORG=
+INFLUX_BUCKET=
+```
+
+---
+
+## 4. Dependencies
+
+### Production
+
+| Package | Purpose |
+|---|---|
+| `astro` | Core framework |
+| `@astrojs/mdx` | MDX integration |
+| `@astrojs/netlify` | Netlify SSR adapter |
+| `@astrojs/rss` | RSS feed generation |
+| `@astrojs/sitemap` | Sitemap generation |
+
+### Dev
+
+| Package | Purpose |
+|---|---|
+| `@biomejs/biome` | Linter + formatter |
+| `@commitlint/cli` | Commit linting |
+| `@commitlint/config-conventional` | Conventional commits preset |
+| `@vitest/coverage-v8` | Coverage reporting |
+| `husky` | Git hooks |
+| `lint-staged` | Run linters on staged files |
+| `npm-check-updates` | Dependency update checker |
+| `vitest` | Unit test runner |
+
+---
+
+## 5. npm Scripts
+
+```jsonc
+{
+  "dev": "astro dev",
+  "build": "astro build",
+  "preview": "astro preview",
+  "start": "astro dev",
+  "lint": "biome lint .",
+  "format": "biome format --write .",
+  "check": "biome check .",
+  "check:fix": "biome check --write .",
+  "test": "vitest run",
+  "test:watch": "vitest",
+  "test:coverage": "npm run test -- --coverage",
+  "dependencies:check": "ncu -e 2",
+  "dependencies:update": "ncu -u && npm i",
+  "prepare": "husky"
+}
+```
+
+---
+
+## 6. Content Collections
+
+### Schema (`src/content/config.ts`)
+
+```ts
+import { defineCollection, z } from 'astro:content';
+
 const blog = defineCollection({
   type: 'content',
   schema: z.object({
@@ -74,55 +310,210 @@ const blog = defineCollection({
     heroImage: z.string().optional(),
   }),
 });
+
+export const collections = { blog };
 ```
 
-### 8. Styling and Assets
-- **Global Styles**: `src/styles/global.css`
-- **Fonts**: Custom Atkinson font family (bold and regular)
-- **Profile Image**: `public/marcos-gil-profile.jpg`
-- **Favicon**: `public/favicon.svg`
+Blog posts go in `src/content/blog/` as `.md` or `.mdx` files with matching frontmatter.
 
-### 9. Build and Deployment
-- **Build Tool**: Astro native build system
-- **Static Output**: Generates static HTML, CSS, and JS
-- **Deployment Platform**: Netlify
-- **Domain**: marcosgilf.com
+---
 
-### 10. Development Tools Integration
-- **Code Quality**: ESLint with Prettier formatting
-- **Git Hooks**: Husky for pre-commit hooks
-- **Commit Standards**: Conventional commits with commitlint
-- **Testing**: Vitest for unit testing with coverage reports
-- **Dependency Management**: npm with automated dependency checking
+## 7. Pages & Routing
 
-## File Structure Overview
+| Route | File | Rendering |
+|---|---|---|
+| `/` | `src/pages/index.astro` | Static |
+| `/about` | `src/pages/about.astro` | Static |
+| `/blog` | `src/pages/blog/index.astro` | Static |
+| `/blog/[slug]` | `src/pages/blog/[...slug].astro` | Static |
+| `/rss.xml` | `src/pages/rss.xml.js` | Static |
+| `/api/track` | `src/pages/api/track.ts` | SSR (`prerender: false`) |
+
+The analytics endpoint (`/api/track`) receives POST requests and writes data to InfluxDB via the line protocol. It reads env vars: `INFLUX_URL`, `INFLUX_TOKEN`, `INFLUX_ORG`, `INFLUX_BUCKET`, `CONTEXT`, `NODE_ENV`.
+
+---
+
+## 8. Components & Utilities
+
+### Components (`src/components/`)
+
+Each component has a co-located `*.test.js` file:
+- `BaseHead.astro` – HTML head, meta/SEO tags
+- `Header.astro` – Site nav header
+- `Footer.astro` – Site footer
+- `FormattedDate.astro` – Date display
+- `HeaderLink.astro` – Nav link
+- `SocialIcons.astro` – Social media icons
+- `ThemeToggle.astro` – Dark/light theme toggle
+
+### Layouts (`src/layouts/`)
+- `BlogPost.astro` – Blog post page wrapper
+
+### Utilities (`src/utils/`)
+- `sort.ts` – Sort posts by `pubDate` descending
+- `title.ts` – Generate page titles (`SITE_TITLE - segment1 - segment2`)
+- `track.ts` – Helpers for analytics: `escapeTagValue`, `normalizeReferrer`, `getCountryFromHeaders`, `parseUserAgent`
+
+### Constants (`src/consts.ts`)
+- `SITE_TITLE` and `SITE_DESCRIPTION` exported for use across pages/components.
+- Values are read from `import.meta.env` with hardcoded fallbacks:
+
+```ts
+export const SITE_TITLE = import.meta.env.SITE_TITLE || 'Marcos Gil';
+export const SITE_DESCRIPTION =
+  import.meta.env.SITE_DESCRIPTION || 'Personal website of Marcos Gil';
 ```
-├── public/                 # Static assets
-├── src/
-│   ├── components/        # Reusable Astro components
-│   ├── content/          # Content collections (blog posts)
-│   ├── layouts/          # Page layout templates
-│   ├── pages/           # File-based routing pages
-│   ├── styles/          # Global CSS styles
-│   └── utils/           # Utility functions
-├── astro.config.mjs     # Astro configuration
-├── package.json         # Dependencies and scripts
-└── tsconfig.json       # TypeScript configuration
-```
 
-## Technology Stack
-- **Framework**: Astro 5.x
-- **Language**: TypeScript
-- **Content**: MDX (Markdown + JSX)
-- **Styling**: CSS
-- **Testing**: Vitest
-- **Linting**: ESLint + Prettier
-- **Deployment**: Netlify
-- **Package Manager**: npm
+---
 
-## Key Constants
-- **Site Title**: "Marcos Gil"
-- **Site Description**: "Personal website of Marcos Gil"
-- **Site URL**: "https://www.marcosgilf.com"
+## 9. Environment Variables
 
-This specification serves as a comprehensive reference for understanding the blog's architecture and functionalities for LLM and coding assistants.
+Configuration is driven by `.env` files loaded automatically by Astro/Vite.
+
+| Variable | Used in | Purpose |
+|---|---|---|
+| `SITE_URL` | `astro.config.mjs` | Canonical site URL (e.g. `https://example.com`) |
+| `SITE_TITLE` | `src/consts.ts` | Site name shown in header, meta, RSS |
+| `SITE_DESCRIPTION` | `src/consts.ts` | Default meta description |
+| `INFLUX_URL` | `src/pages/api/track.ts` | InfluxDB write endpoint |
+| `INFLUX_TOKEN` | `src/pages/api/track.ts` | InfluxDB auth token |
+| `INFLUX_ORG` | `src/pages/api/track.ts` | InfluxDB organisation |
+| `INFLUX_BUCKET` | `src/pages/api/track.ts` | InfluxDB bucket |
+| `CONTEXT` | `src/pages/api/track.ts` | Netlify deploy context (`production`, `deploy-preview`, …) |
+
+**File loading order** (Astro/Vite):
+- `astro dev` → `.env.development` > `.env`
+- `astro build` → `.env.production` > `.env`
+- `.env.development` is committed with safe dev defaults.
+- `.env` and `.env.production` are gitignored (contain secrets).
+
+**How values reach the code**:
+- `astro.config.mjs` uses Vite's `loadEnv()` to read `SITE_URL` (config runs before Vite).
+- `src/consts.ts` reads `SITE_TITLE` / `SITE_DESCRIPTION` from `import.meta.env` with hardcoded fallbacks.
+- `src/pages/api/track.ts` reads InfluxDB vars from `process.env` at request time (SSR).
+
+---
+
+## 10. Testing
+
+- **Runner**: Vitest with `getViteConfig` from Astro for Astro-aware transforms.
+- **Coverage**: `@vitest/coverage-v8`.
+- **Pattern**: Co-located test files (`*.test.js` / `*.test.ts`) next to source.
+- **Run**: `npm test` (single run), `npm run test:watch`, `npm run test:coverage`.
+
+---
+
+## 11. Linter & Formatter
+
+- **Tool**: Biome (single tool for lint + format).
+- **Config**: `biome.json` (see §3.3).
+- Overrides disable `noUnusedVariables`/`noUnusedImports` for `.astro` files and `noImportantStyles` for `.css` files.
+- `lint-staged` runs `biome check --write` on staged files via Husky pre-commit hook.
+
+---
+
+## 12. Git Hooks & Commit Standards
+
+- **Husky** initialised via `"prepare": "husky"` script.
+- **Pre-commit** (`.husky/pre-commit`):
+  1. `npx lint-staged` – run Biome check on staged files.
+  2. `npm run dependencies:check` – warn if outdated deps exist.
+- **Commit messages**: Enforced by `commitlint` with `@commitlint/config-conventional`.
+
+---
+
+## 13. GitHub Actions
+
+### 13.1 CI (`.github/workflows/ci.yml`)
+
+Triggers on PRs to `main` and pushes to `main`.
+
+**Job: `lint-and-test`**
+1. Checkout → Setup Node (from `.nvmrc`, npm cache) → `npm ci`
+2. `npm run lint`
+3. `npm test`
+
+**Job: `build`** (needs `lint-and-test`)
+1. Checkout → Setup Node → `npm ci`
+2. `npm run build`
+3. Upload `dist` artifact
+4. Upload `.netlify` artifact
+
+**Job: `deploy-preview`** (needs `build`, PRs only)
+- Calls reusable workflow `deploy-preview.yml`
+- Requires repo var `NETLIFY_SITE_ID` and secret `NETLIFY_AUTH_TOKEN`
+
+### 13.2 Deploy Preview (`.github/workflows/deploy-preview.yml`)
+
+Reusable workflow (`workflow_call`).
+1. Downloads `dist` and `.netlify` artifacts.
+2. Deploys to Netlify (non-prod) via `netlify-cli deploy --dir=dist --no-build`.
+3. Posts/updates a PR comment with the preview URL using `actions/github-script`.
+- Permissions: `contents: read`, `pull-requests: write`, `issues: write`, `deployments: write`, `statuses: write`.
+
+### 13.3 Production Deploy (`.github/workflows/deploy.yml`)
+
+Triggers on push to `main`.
+1. Checkout → Setup Node → `npm ci` → `npm run build`
+2. `netlify-cli deploy --dir=dist --no-build --prod`
+- Requires secret `NETLIFY_AUTH_TOKEN` and var `NETLIFY_SITE_ID`.
+
+### 13.4 DNS Drift Check (`.github/workflows/dns-drift-check.yml`)
+
+Triggers on `workflow_dispatch` and daily cron (`0 0 * * *`).
+1. Installs `dnsutils` + `curl`.
+2. Verifies authoritative nameservers match expected DNS provider.
+3. Verifies A records for apex and www do not resolve to a previous hosting provider.
+4. Runs HTTPS sanity check ensuring no stale `Server` header.
+
+> **Generic note**: Adapt the expected nameservers, IPs, and domains to your own setup.
+
+---
+
+## 14. Infrastructure (Terraform)
+
+### 14.1 Netlify (`infra/netlify/`)
+
+| File | Purpose |
+|---|---|
+| `versions.tf` | Terraform ≥ 1.6, `netlify/netlify` provider `~> 0.4` |
+| `providers.tf` | Provider config (auth via `NETLIFY_TOKEN` env var) |
+| `variables.tf` | `team_slug`, `team_id`, `domain`, `site_id`, InfluxDB vars, tracking vars |
+| `main.tf` | `netlify_dns_zone` resource for root domain |
+| `env.tf` | `netlify_environment_variable` resources for InfluxDB and tracking config (production context) |
+| `outputs.tf` | Outputs `zone_id` and `nameservers` |
+| `terraform.tfvars.example` | Example variable values |
+
+**State**: Local backend (`terraform.tfstate`, gitignored).
+
+### 14.2 Grafana (`infra/grafana/`)
+
+| File | Purpose |
+|---|---|
+| `versions.tf` | Terraform ≥ 1.5, `grafana/grafana` provider `~> 3.12`, local backend |
+| `main.tf` | Provider config, `grafana_folder` + dynamic `grafana_dashboard` from JSON files |
+| `variables.tf` | `grafana_url`, `grafana_api_token` (sensitive), `grafana_org_id`, `dashboard_folder`, `dashboards_path` |
+| `dashboards/` | Exported Grafana dashboard JSON files |
+| `terraform.tfvars.example` | Example variable values |
+
+**State**: Local backend.
+
+---
+
+## 15. Replication Checklist
+
+1. **Scaffold**: `npm create astro@latest` → choose blog template / empty.
+2. **Install deps**: Add all production and dev dependencies from §4.
+3. **Config files**: Create all files from §3 (astro, tsconfig, biome, vitest, commitlint, lint-staged, husky, nvmrc, gitignore, `.env.example`, `.env.development`).
+4. **Project structure**: Create folder tree from §2.
+5. **Content schema**: Add `src/content/config.ts` from §6.
+6. **Pages**: Create routes listed in §7.
+7. **Components**: Create components and layouts from §8 with co-located tests.
+8. **Utilities**: Create utils from §8 with co-located tests.
+9. **Constants**: Create `src/consts.ts` with env-driven site title/description exports.
+10. **Environment**: Copy `.env.example` to `.env` and fill in real values (see §9).
+11. **npm scripts**: Add all scripts from §5 to `package.json`.
+12. **Husky setup**: Run `npx husky init`, create `.husky/pre-commit` from §3.7.
+13. **GitHub Actions**: Create all workflow files from §13.
+14. **Infra**: Create Terraform modules from §14 (adapt vars to your providers/accounts).
+15. **Verify**: `npm run lint`, `npm test`, `npm run build` should all pass.

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -1,5 +1,6 @@
 // Place any global data in this file.
 // You can import this data from anywhere in your site by using the `import` keyword.
 
-export const SITE_TITLE = 'Marcos Gil';
-export const SITE_DESCRIPTION = 'Personal website of Marcos Gil';
+export const SITE_TITLE = import.meta.env.SITE_TITLE || 'Marcos Gil';
+export const SITE_DESCRIPTION =
+  import.meta.env.SITE_DESCRIPTION || 'Personal website of Marcos Gil';

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -3,14 +3,13 @@ import BaseHead from '../components/BaseHead.astro';
 import Footer from '../components/Footer.astro';
 import FormattedDate from '../components/FormattedDate.astro';
 import Header from '../components/Header.astro';
-import { SITE_DESCRIPTION } from '../consts';
 import { getPageTitle } from '../utils/title';
 
 const title = 'About Me';
 const description =
-  'Senior Software Engineer with 10+ years of experience in web development, architecture, and quality engineering.';
+  'AI Engineer path from a Senior Software Engineer background, focused on agent systems, evaluation, and secure automation.';
 // const pubDate = new Date('January 30 2024');
-const updatedDate = new Date('February 4 2026');
+const updatedDate = new Date('February 18 2026');
 ---
 
 <html lang="en">
@@ -34,106 +33,131 @@ const updatedDate = new Date('February 4 2026');
           <hr />
         </header>
         <section>
-  <p>
-    Senior Software Engineer with over a decade of experience building production-grade web applications.
-    I bring a strong foundation in systems thinking, engineering rigor, and cross-layer understanding
-    spanning frontend, backend, DevOps, and quality engineering.
-  </p>
+          <p>
+            Senior Software Engineer with over a decade of experience building production-grade web applications.
+            I bring a strong foundation in systems thinking, engineering rigor, and cross-layer understanding
+            spanning frontend, backend, DevOps, and quality engineering.
+          </p>
 
-  <h2>Current Focus: Applied AI Engineering</h2>
-  <p>
-    I'm actively transitioning into <strong>Applied AI Engineering</strong>, focusing on building
-    production-grade AI agents and automation systems. My interests include:
-  </p>
-  <ul>
-    <li><strong>AI Agent Systems</strong> — Tool-using agents with loops, memory, and measurable evaluation</li>
-    <li><strong>Skills Libraries</strong> — Modular, composable primitives that teams can assemble into workflows</li>
-    <li><strong>Agent Reliability</strong> — Observability, tracing, retries, and regression testing for agentic systems</li>
-    <li><strong>Workflow Automation</strong> — Autonomous workflows for business operations with human-in-the-loop patterns</li>
-    <li><strong>AI Development Environments</strong> — Templates, patterns, and documentation that enable teams to ship AI-powered features</li>
-  </ul>
-  <p>
-    I approach AI engineering with the same production mindset I bring to traditional software:
-    if it can't be evaluated and reproduced, it's not done.
-  </p>
+          <h2>Current Focus: AI Engineer Path</h2>
+          <p>
+            I'm actively evolving toward an <strong>AI Engineer</strong> profile. AI Agents are my initial
+            specialization domain because they combine runtime engineering, tool orchestration, evaluation,
+            automation, and operational rigor.
+          </p>
+          <ul>
+            <li>
+              <strong>AI Agent Systems</strong> — Tool-using agents with explicit loops, memory boundaries,
+              and termination criteria
+            </li>
+            <li><strong>Evaluation & Regression</strong> — Repeatable benchmarks, failure analysis, and behavior comparisons</li>
+            <li><strong>Secure Agent Operations</strong> — Threat-model-first design, deny-by-default access, and auditability</li>
+            <li><strong>Async/Background Workflows</strong> — Long-running automations with run artifacts and clear status</li>
+            <li><strong>Cost & Context Quality</strong> — Model routing, caching, and memory/context discipline</li>
+          </ul>
+          <p>
+            I work iteratively in the free slots available each day. The rule is simple:
+            finish each work session with one concrete artifact (code, test, run report, or documentation)
+            and one clearly defined next step.
+          </p>
 
-  <h2>Core Competencies</h2>
-  <h3>Frontend & UI Engineering</h3>
-  <ul>
-    <li>React ecosystem with TypeScript</li>
-    <li>Component-driven development with Storybook</li>
-    <li>Modern CSS (Sass, CSS Custom Properties, CSS Grid)</li>
-    <li>Accessibility (A11y) and UX best practices</li>
-  </ul>
+          <h2>Current Starting Platform: Nanobot</h2>
+          <p>
+            Nanobot is my active starting platform because it has a low learning curve and immediate
+            deployability for real-world workflows. It is a launchpad, not the final boundary of my roadmap.
+          </p>
+          <ul>
+            <li><strong>Infrastructure & Deploy</strong> — Terraform + VPS operations and deployment automation</li>
+            <li><strong>LLM Router</strong> — Tiered model routing, budget control, and usage visibility</li>
+            <li><strong>Memory Manager</strong> — Persistent context and memory lifecycle management</li>
+            <li><strong>Gym Booker</strong> — Real automation use case with reliability and operations constraints</li>
+            <li>
+              <strong>Platform Progression</strong> — Expand next into OpenClaw, AgentZero hardening patterns,
+              and OpenCode async operations
+            </li>
+          </ul>
+          <p>
+            My operating standard is production-minded AI engineering: if behavior cannot be measured,
+            replayed, and explained, it's not done.
+          </p>
 
-  <h3>Quality & Testing</h3>
-  <ul>
-    <li>Unit and integration testing with Vitest/Jest</li>
-    <li>End-to-end testing strategies</li>
-    <li>Code quality tooling (ESLint, Prettier, Biome)</li>
-    <li>Pre-commit hooks and automated checks (Husky, lint-staged)</li>
-  </ul>
+          <h2>Core Competencies</h2>
+          <h3>Frontend & UI Engineering</h3>
+          <ul>
+            <li>React ecosystem with TypeScript</li>
+            <li>Component-driven development with Storybook</li>
+            <li>Modern CSS (Sass, CSS Custom Properties, CSS Grid)</li>
+            <li>Accessibility (A11y) and UX best practices</li>
+          </ul>
 
-  <h3>Backend & Infrastructure</h3>
-  <ul>
-    <li>Node.js and Express for API development</li>
-    <li>CI/CD pipelines with GitHub Actions</li>
-    <li>Infrastructure as Code with Terraform</li>
-    <li>Cloud platforms (GCP)</li>
-  </ul>
+          <h3>Quality & Testing</h3>
+          <ul>
+            <li>Unit and integration testing with Vitest/Jest</li>
+            <li>End-to-end testing strategies</li>
+            <li>Code quality tooling (ESLint, Prettier, Biome)</li>
+            <li>Pre-commit hooks and automated checks (Husky, lint-staged)</li>
+          </ul>
 
-  <h3>Engineering Practices</h3>
-  <ul>
-    <li>Systems architecture and design</li>
-    <li>Agile methodologies (Kanban, Scrum)</li>
-    <li>Version control and collaborative workflows (Git, GitHub)</li>
-    <li>Production-first mindset with observability and reliability focus</li>
-  </ul>
+          <h3>Backend & Infrastructure</h3>
+          <ul>
+            <li>Node.js and Express for API development</li>
+            <li>CI/CD pipelines with GitHub Actions</li>
+            <li>Infrastructure as Code with Terraform</li>
+            <li>Cloud platforms (GCP)</li>
+          </ul>
 
-  <h2>Current Role: IKEA</h2>
-  <p>
-    Senior Software Engineer at IKEA Digital Hub in Madrid ("Madhult"), where I work on digital products
-    serving business clients and in-store experiences:
-  </p>
-  <ul>
-    <li><strong>IKEA for Business</strong> — B2B e-commerce platform optimizing the purchasing journey</li>
-    <li><strong>Physical Meeting Points</strong> — Digital touchpoints for in-store customer interactions</li>
-    <li><strong>IKEA Food</strong> — Digital solutions for food service operations</li>
-  </ul>
+          <h3>Engineering Practices</h3>
+          <ul>
+            <li>Systems architecture and design</li>
+            <li>Agile methodologies (Kanban, Scrum)</li>
+            <li>Version control and collaborative workflows (Git, GitHub)</li>
+            <li>Production-first mindset with observability and reliability focus</li>
+          </ul>
 
-  <h2>Previous Experience</h2>
-  <h3>ING</h3>
-  <p>
-    Frontend engineer on a multi-country banking platform, implementing web standards-based architecture
-    with Polymer, Web Components, ES6, and CSS Grid. Delivered a scalable solution deployed across
-    ING Group countries.
-  </p>
+          <h2>Current Role: IKEA</h2>
+          <p>
+            Senior Software Engineer at IKEA Digital Hub in Madrid ("Madhult"), where I work on digital products
+            serving business clients and in-store experiences:
+          </p>
+          <ul>
+            <li><strong>IKEA for Business</strong> — B2B e-commerce platform optimizing the purchasing journey</li>
+            <li><strong>Physical Meeting Points</strong> — Digital touchpoints for in-store customer interactions</li>
+            <li><strong>IKEA Food</strong> — Digital solutions for food service operations</li>
+          </ul>
 
-  <h3>Babel</h3>
-  <p>
-    Full-stack development with Java backend (Spring MVC, JSF) and JavaScript frontend (Backbone, Marionette).
-    Practiced BDD with Concordion and Selenium for automated acceptance testing.
-  </p>
+          <h2>Previous Experience</h2>
+          <h3>ING</h3>
+          <p>
+            Frontend engineer on a multi-country banking platform, implementing web standards-based architecture
+            with Polymer, Web Components, ES6, and CSS Grid. Delivered a scalable solution deployed across
+            ING Group countries.
+          </p>
 
-  <h2>Education</h2>
-  <p>
-    <strong>Degree in Industrial Technology Engineering</strong><br />
-    Universidad Politécnica de Madrid<br />
-    Specialization in Automation and Electronics
-  </p>
-  <p>
-    Transitioned from industrial engineering to software development, combining analytical foundations
-    with a passion for building digital products.
-  </p>
+          <h3>Babel</h3>
+          <p>
+            Full-stack development with Java backend (Spring MVC, JSF) and JavaScript frontend (Backbone, Marionette).
+            Practiced BDD with Concordion and Selenium for automated acceptance testing.
+          </p>
 
-  <h2>Get in Touch</h2>
-  <p>
-    Interested in connecting? Find me on <a
-      href="https://www.linkedin.com/in/marcosgilfernandez/?locale=en_US"
-      target="_blank"
-      rel="noopener noreferrer"
-    >LinkedIn</a>.
-  </p>
+          <h2>Education</h2>
+          <p>
+            <strong>Degree in Industrial Technology Engineering</strong><br />
+            Universidad Politécnica de Madrid<br />
+            Specialization in Automation and Electronics
+          </p>
+          <p>
+            Transitioned from industrial engineering to software development, combining analytical foundations
+            with a passion for building digital products.
+          </p>
+
+          <h2>Get in Touch</h2>
+          <p>
+            Interested in connecting? Find me on <a
+              href="https://www.linkedin.com/in/marcosgilfernandez/?locale=en_US"
+              target="_blank"
+              rel="noopener noreferrer"
+            >LinkedIn</a>.
+          </p>
         </section>
       </article>
     </main>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -18,19 +18,22 @@ import { getPageTitle } from '../utils/title';
       <h1>Hola! I'm Marcos Gil</h1>
       <p>Welcome to my personal space on the internet.</p>
       <p>
-        I'm a software engineer based in Madrid, Spain, currently working at <a
+        I'm a Senior Software Engineer based in Madrid, Spain, currently working at <a
           href="https://www.IKEA.com/"
           target="_blank"
           rel="noopener noreferrer"
         >IKEA</a>.
       </p>
-      <p>Look.</p>
       <p>
-        Here, I share my thoughts, experiences, and insights on software development and beyond.
-        Join me as we explore the world together.
+        Here I share practical notes, learnings, and experiments from my transition toward an AI Engineer profile.
       </p>
       <p>
-        Currently, I'm digging into the AI world, I'm using it heavily for programming and I'm investigating the agents landscape.
+        My current starting domain is AI Agents: tool-using systems, evaluation, reliability, and secure automation.
+        I work iteratively and focus on small, concrete artifacts each session.
+      </p>
+      <p>
+        Nanobot is my active starting platform due to its low learning curve and deployability, and I progressively
+        expand the roadmap toward OpenClaw, AgentZero, and OpenCode.
       </p>
       <p>Now that you are here, you can learn more about me in:</p>
       <nav>


### PR DESCRIPTION
Summary
- Revise `docs/ai-engineer.md` and `docs/plan.md` to keep the AI Engineer framing, replace time-based cadence with iterative, availability-driven execution, and add the requested control tables, workstream structure, and Naonbot-first roadmap aligned to 2026/2027 trends.
- Capture v2 change logs, document control metadata, and the expanded platform progression map plus learning/selection guidance so the new specs and nanobot focus are clearly contextualized for future updates.
- Align surrounding content (about/index, constants, config, specs, env/globs, package metadata) to match the refocused plan and agents direction per the latest instructions.

Testing
- Not run (not requested)